### PR TITLE
Bug/empty param validation

### DIFF
--- a/stpmex/auth.py
+++ b/stpmex/auth.py
@@ -60,7 +60,7 @@ def join_fields(obj: 'Resource', fieldnames: List[str]) -> bytes:  # noqa: F821
             value = f'{value:.2f}'
         elif isinstance(value, Enum) and value:
             value = value.value
-        elif value is None:
+        elif not value:
             value = ''
         joined_fields.append(str(value))
     return '||' + '|'.join(joined_fields) + '||'

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -10,7 +10,7 @@ def test_join_fields_for_orden(orden):
     joined = (
         '||40072|TAMIZI|||CR1564969083|90646|1.20|1|40||646180110400000007|'
         '|40|Ricardo Sanchez|072691004495711499|ND||||||Prueba||||||5273144|'
-        '|T||3|0|||'
+        '|T||3||||'
     )
     assert join_fields(orden, ORDEN_FIELDNAMES) == joined
 
@@ -23,9 +23,9 @@ def test_join_fields_for_cuenta(cuenta):
 
 def test_compute_signature(client, orden):
     firma = (
-        'KDNKDVVuyNt9oTXPAlofGXGH5L5IH9PAzOsx0JZFtmGlU+10QRf2RHSg0OVCnYYpu5sC3'
-        'DJ6vlXuYM40+uNw0tMc0y8Dv26uO8Vv2GhOhMqaGk72LwgwgmqVg17xzjgGbJHzAzMav3'
-        'fx4/3No+mSnf7vxpe4ePf6yK1yU5U28L4='
+        'nuW3v3gV5GqQCGiIfUGOrENSZK+bYRR3RZ8xT0wNm+p+XowkogURPEuFRk2SwkjNn6HUN'
+        'XP3OkHFe92s0ViyLad7nN5n8pIvmGdOLopBtXvYBNhJmuCw2D32oGDWm7fKydW17NR9BY'
+        'xJFdqSJzMGq4dquFI3ZuG6YfVHo4NYE5A='
     )
     sig = compute_signature(client.pkey, join_fields(orden, ORDEN_FIELDNAMES))
     assert sig == firma


### PR DESCRIPTION
Closes Fondeadora/fondeadora#1123

### Description

Se corrige la validación de parámetros vacíos en la librería 

### What is the current behavior?

Ya no se evalúa sólo los tipos `None`

### What is the new behavior?

Ahora se evalúa si la variable está vacía en concreto 

### How was it tested?

- [x] pytest

### Checklist

- [x] Does your code follow the project style guide?
