### PR TITLE
fix: fix generic exception on account registration

### DIFF
--- a/stpmex/client.py
+++ b/stpmex/client.py
@@ -162,6 +162,8 @@ def _raise_description_exc(resp: Dict) -> NoReturn:
     id = resp['id']
     desc = resp['descripcion']
 
+    if id == 0 and desc == 'Cuenta en revisión.':
+        return True
     if id == 1 and desc == 'Cuenta Duplicada':
         raise DuplicatedAccount(**resp)
     elif id == 1 and desc == 'rfc/curp invalido':

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import pytest
 from requests import HTTPError
 
@@ -163,3 +165,17 @@ def test_errors(
     assert type(exc) is expected_exc
     assert repr(exc)
     assert str(exc)
+
+
+def test_account_registration() -> None:
+    with patch('stpmex.client.Session') as mock_session:
+        mock_session().request().json.return_value = {
+            'descripcion': 'Cuenta en revisión.',
+            'id': 0,
+        }
+        client = Client('TAMIZI', PKEY, '12345678')
+
+        response = client.put(CUENTA_ENDPOINT, dict(firma='{hola}'))
+        assert type(response) is dict
+        assert response['id'] == 0
+        assert response['descripcion'] == 'Cuenta en revisión.'


### PR DESCRIPTION
Closes Fondeadora/fondeadora#1249

### Description

Fixes an issue where an exception would be raised when an account is registered in STP and it's in a verifying state.

### What is the current behavior?

A recent change in STP caused that when an account is registered it's checked against several denylists, this puts the recently registered acocunt in a "verifying" state, which STP returns in the description of the response and when checking the response the library assumes it's an unexpected behavior and raises a generic `StpmexException(descripcion='Cuenta en revisión.', id=0)`.

### What is the new behavior?

Per the STP documentation, any response with `id=0` means the request was OK, so this is not an exceptional state, it's expected to happen, so we just return `True` when checking the response insted of raising an error and continue with the execution.

### How was it tested?

- [x] pytest

### Checklist

- [x] Does your code follow the project style guide?
- [x] Have you added tests that cover the changes and run them?

### Additional Context

N/A