### PR TITLE
feat: default transfer payment type to 30

### DIFF
--- a/stpmex/resources/ordenes.py
+++ b/stpmex/resources/ordenes.py
@@ -68,7 +68,7 @@ class Orden(Resource):
 
     prioridad: int = Prioridad.normal.value
     medioEntrega: int = 3
-    tipoPago: int = 1
+    tipoPago: int = 30
     topologia: str = 'T'
     iva: Optional[float] = None
 


### PR DESCRIPTION
Closes Fondeadora/fondeadora#197

### Description
We update the default payment type by banxico requirements.

### What is the current behavior?
Payment type is tercero_a_tercero.

### What is the new behavior?
Payment type is tercero_indirecto_a_tercero.

### How was it tested?
- [ ] unit
- [ ] dev

<!-- Add here any additional context you think is important. -->
